### PR TITLE
Enable CORS for server

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -87,6 +87,17 @@ Server.prototype.getSSLServerOptions = function() {
 
 Server.prototype.createServerCallback = function() {
   return (function(request, response) {
+    // Based on https://gist.github.com/balupton/3696140
+    response.setHeader('Access-Control-Allow-Origin', '*');
+    response.setHeader('Access-Control-Request-Method', '*');
+    response.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET, POST');
+    response.setHeader('Access-Control-Allow-Headers', '*');
+    if (request.method === 'OPTIONS') {
+      response.writeHead(200);
+      response.end();
+      return;
+    }
+    
     var theUrl = request.url;
     var theUrlParts = url.parse(theUrl, true);
     var theUrlParams = theUrlParts.query;


### PR DESCRIPTION
I am building a webpage that enables guests in my house to toggle the buttons. However, the webpage is on another domain, so JavaScript was not able to request the urls because of CORS issues. I added the headers that should fix this.

I am not sure if the "Access-Control-Allow-Methods" header has the correct values for all possible scenarios.