### PR TITLE
Update HttpWebHookWindowCoveringAccessory.js

### DIFF
--- a/src/homekit/accessories/HttpWebHookWindowCoveringAccessory.js
+++ b/src/homekit/accessories/HttpWebHookWindowCoveringAccessory.js
@@ -104,7 +104,7 @@ HttpWebHookWindowCoveringAccessory.prototype.changeFromServer = function(urlPara
 }
 
 HttpWebHookWindowCoveringAccessory.prototype.getTargetPosition = function(callback) {
-  this.log("Getting current Target Position for '%s'...", this.id);
+  this.log.debug("Getting current Target Position for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-target-position-" + this.id);
   if (state === undefined) {
     state = 100;
@@ -114,7 +114,7 @@ HttpWebHookWindowCoveringAccessory.prototype.getTargetPosition = function(callba
 
 HttpWebHookWindowCoveringAccessory.prototype.setTargetPosition = function(newState, callback, context) {
   this.log("Target Position State for '%s'...", this.id);
-  this.log("new target state is: " + newState);
+  this.log("New target state is: " + newState);
   this.storage.setItemSync("http-webhook-target-position-" + this.id, newState);
   if(this.autoSetCurrentPosition) {
     this.storage.setItemSync("http-webhook-current-position-" + this.id, newState);
@@ -170,7 +170,7 @@ HttpWebHookWindowCoveringAccessory.prototype.setTargetPosition = function(newSta
   Util.callHttpApi(this.log, urlToCall, urlMethod, urlBody, urlForm, urlHeaders, this.rejectUnauthorized, callback, context, (function() {
     this.service.getCharacteristic(Characteristic.TargetPosition).updateValue(newState, undefined, null);
     if(this.autoSetCurrentPosition) {
-      this.log("new current state is: " + newState);
+      this.log("New current state is: " + newState);
       setTimeout(function() {
         this.service.getCharacteristic(Characteristic.CurrentPosition).updateValue(newState, undefined, null);
       }.bind(this), 1000);
@@ -179,7 +179,7 @@ HttpWebHookWindowCoveringAccessory.prototype.setTargetPosition = function(newSta
 };
 
 HttpWebHookWindowCoveringAccessory.prototype.getCurrentPosition = function(callback) {
-  this.log("Getting Current Position for '%s'...", this.id);
+  this.log.debug("Getting Current Position for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-current-position-" + this.id);
   if (state === undefined) {
     state = 100;
@@ -188,7 +188,7 @@ HttpWebHookWindowCoveringAccessory.prototype.getCurrentPosition = function(callb
 };
 
 HttpWebHookWindowCoveringAccessory.prototype.getPositionState = function(callback) {
-  this.log("Getting position state for '%s'...", this.id);
+  this.log.debug("Getting position state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-position-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.PositionState.STOPPED;


### PR DESCRIPTION
Moved logging for getCurrentPosition and getPositionState and getTargetPosition to debug level to reduce flooding of logs