### PR TITLE
Keys case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ To update a thermostat you can update four different values:
 
 # Security System
 To update the state of security, you can update two different values:
-* Current state (Stay=0 / Away=1 / Night=2 / Disarmed=3 / Triggered=4): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&currentstate=NEWVALUE`
-* Target state (Stay=0 / Away=1 / Night=2 / Disarm=3): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&targetstate=NEWVALUE`
+* Current state (Stay=0 / Away=1 / Night=2 / Disarmed=3 / Triggered=4): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&currentState=NEWVALUE`
+* Target state (Stay=0 / Away=1 / Night=2 / Disarm=3): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&targetState=NEWVALUE`
 
 # Garage Door opener
 To update a garage door opener you can update three different values:
@@ -136,8 +136,8 @@ To update a lock mechanism you can update two different values:
 
 # Window Coverings
 To update a window coverings you can update three different values:
-* Current position (%): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&currentposition=%s` (%s is replaced by corresponding current position)
-* Target position (%): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&targetposition=%s` (%s is replaced by corresponding target position)
+* Current position (%): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&CurrentPosition=%s` (%s is replaced by corresponding current position)
+* Target position (%): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&TargetPosition=%s` (%s is replaced by corresponding target position)
 Setting of target position you can realize by send link to: open, 20%, 40%, 60% 80% and close
 * Position State (Decreasing=0 / Increasing=1 / Stopped=2): `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&positionstate=0 (1 or 2)` (position state is not mandatory and not fully tested yet)
 


### PR DESCRIPTION
When i use the api I get
{"success":true,"currentState":"","targetState":"0"}
{"success":true,"CurrentPosition":"1","TargetPosition":"1"}
But when I change the case I get
{"success":true}