### PR TITLE
Update package.json to add extra search keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "plugin",
     "http",
     "webhook",
+    "httpwebhooks",
+    "http-webhooks",
+    "http webhooks",
     "smart",
     "homekit",
     "siri"


### PR DESCRIPTION
Previously a search for "httpwebhooks" would not find this plugin. 
This PR adds extra keywords to the package.json to ensure the plugin can be more easily found in a Homebridge search
