### PR TITLE
adjust variable name for thermostat temperatures

### DIFF
--- a/src/homekit/accessories/HttpWebHookThermostatAccessory.js
+++ b/src/homekit/accessories/HttpWebHookThermostatAccessory.js
@@ -13,7 +13,7 @@ function HttpWebHookThermostatAccessory(ServiceParam, CharacteristicParam, platf
   this.name = thermostatConfig["name"];
   this.type = "thermostat";
   this.minValue = thermostatConfig["minTemp"] || 15;
-  this.maxValue = thermostatConfig["maxValue"] || 30;
+  this.maxValue = thermostatConfig["maxTemp"] || 30;
   this.minStep = thermostatConfig["minStep"] || 0.5;
   this.rejectUnauthorized = thermostatConfig["rejectUnauthorized"] === undefined ? true: thermostatConfig["rejectUnauthorized"] === true;
   this.setTargetTemperatureURL = thermostatConfig["set_target_temperature_url"] || "";


### PR DESCRIPTION
as shown in issue #180 
The variable for the min and max values of the thermostat were messed up, made them follow the same naming convention. 

Possibly breaking change because the variable name has changed. 
Documentation already reflects the change, even before this pr. 