### PR TITLE
Add state toggling for switch

### DIFF
--- a/src/homekit/accessories/HttpWebHookSwitchAccessory.js
+++ b/src/homekit/accessories/HttpWebHookSwitchAccessory.js
@@ -44,8 +44,10 @@ HttpWebHookSwitchAccessory.prototype.changeFromServer = function(urlParams) {
     };
   }
   else {
-    var state = urlParams.state;
     var stateBool = state === "true";
+    if (urlParams.state === "toggle") {
+      stateBool = !cachedState
+    }
     this.storage.setItemSync("http-webhook-" + this.id, stateBool);
     // this.log("[INFO Http WebHook Server] State change of '%s'
     // to '%s'.",accessory.id,stateBool);


### PR DESCRIPTION
This PR adds logic to the switch to toggle state instead of sending a fixed `state=true` or `state=false`. Now you can send `state=toggle` in order to make the switch go into the other state

Solves #177 