### PR TITLE
Upgrade `http-auth` to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "homebridge": ">=0.3.0"
   },
   "dependencies": {
-    "http-auth": "^3.2.4",
+    "http-auth": "^4.2.0",
     "node-persist": "2.0.x",
     "request": "2.87.x",
     "selfsigned": "^1.10.7"

--- a/src/Server.js
+++ b/src/Server.js
@@ -172,10 +172,10 @@ Server.prototype.start = function() {
       callback(username === httpAuthUser && password === httpAuthPass);
     });
     if(this.https) {
-      https.createServer(basicAuth, sslServerOptions, serverCallback).listen(this.webhookPort, this.webhookListenHost);
+      https.createServer(sslServerOptions, basic.check(serverCallback)).listen(this.webhookPort, this.webhookListenHost);
     }
     else {
-      http.createServer(basicAuth, serverCallback).listen(this.webhookPort, this.webhookListenHost);
+      http.createServer(basic.check(serverCallback)).listen(this.webhookPort, this.webhookListenHost);
     }
   }
   else {


### PR DESCRIPTION
V4 removes monkey patching of the `http` which is a bit risky and confusing (https://github.com/gevorg/http-auth/commit/54091adfe2cd8626121f2e7e319a04f209a55f74), so thought it would be good to upgrade.

Note I don't have this running locally atm so haven't tested it, but from the docs it looks like it should work
