### PR TITLE
Reduce logging level of garage state retrieval

### DIFF
--- a/src/homekit/accessories/HttpWebHookGarageDoorOpenerAccessory.js
+++ b/src/homekit/accessories/HttpWebHookGarageDoorOpenerAccessory.js
@@ -118,7 +118,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.setTargetDoorState = function(new
 };
 
 HttpWebHookGarageDoorOpenerAccessory.prototype.getCurrentDoorState = function(callback) {
-  this.log("Getting Current Door State for '%s'...", this.id);
+  this.debug("Getting Current Door State for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-current-door-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.CurrentDoorState.CLOSED;


### PR DESCRIPTION
Unlike other accessories, the garage door spams its get state message once a minute to the `info` level. Reducing this level to `debug` matches the behavior of other accessories.