### PR TITLE
Add Accessory Name to log entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### NEXT VERSION
+New features:
+  - Added accessory names to log entries
+
+
 ### 0.1.18
 
 Bugfix:

--- a/src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory.js
+++ b/src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory.js
@@ -26,7 +26,7 @@ function HttpWebHookCarbonDioxideSensorAccessory(ServiceParam, CharacteristicPar
 HttpWebHookCarbonDioxideSensorAccessory.prototype.changeFromServer = function(urlParams) {
   var cached = this.storage.getItemSync("http-webhook-" + this.id) || 0;
   if (urlParams.value === undefined) {
-    this.log.debug("No urlValue");
+    this.log.debug(this.name + ": No urlValue");
     return {
       "success" : true,
       "state" : cached
@@ -34,14 +34,14 @@ HttpWebHookCarbonDioxideSensorAccessory.prototype.changeFromServer = function(ur
   }
   var urlValue = urlParams.value;
   var co2Detected = urlValue > this.co2PeakLevel;
-  this.log.debug("urlValue: "+ urlValue);
-  this.log.debug("co2Detected: "+ co2Detected);
+  this.log.debug(this.name + ": urlValue: "+ urlValue);
+  this.log.debug(this.name + ": co2Detected: "+ co2Detected);
   this.storage.setItemSync("http-webhook-carbon-dioxide-level-" + this.id, urlValue);
   this.storage.setItemSync("http-webhook-carbon-dioxide-detected-" + this.id, co2Detected);
-  this.log.debug("cached: "+ cached);
-  this.log.debug("cached !== urlValue: "+ (cached !== urlValue));
+  this.log.debug(this.name + ": cached: "+ cached);
+  this.log.debug(this.name + ": cached !== urlValue: "+ (cached !== urlValue));
   if (cached !== urlValue) {
-    this.log("Change HomeKit value for " + this.type + " sensor to '%s'.", urlValue);
+    this.log(this.name + ": Change HomeKit value for " + this.type + " sensor to '%s'.", urlValue);
     this.service.getCharacteristic(Characteristic.CarbonDioxideLevel).updateValue(urlValue, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     this.service.getCharacteristic(Characteristic.CarbonDioxideDetected).updateValue(co2Detected ? Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL : Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL, undefined, Constants.CONTEXT_FROM_WEBHOOK);
   }
@@ -51,7 +51,7 @@ HttpWebHookCarbonDioxideSensorAccessory.prototype.changeFromServer = function(ur
 }
 
 HttpWebHookCarbonDioxideSensorAccessory.prototype.getCarbonDioxideLevel = function(callback) {
-  this.log.debug("Getting carbon dioxide level for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting carbon dioxide level for '%s'...", this.id);
   var temp = this.storage.getItemSync("http-webhook-carbon-dioxide-level-" + this.id);
   if (temp === undefined) {
     temp = 0;
@@ -60,7 +60,7 @@ HttpWebHookCarbonDioxideSensorAccessory.prototype.getCarbonDioxideLevel = functi
 };
 
 HttpWebHookCarbonDioxideSensorAccessory.prototype.getCarbonDioxideDetected = function(callback) {
-    this.log.debug("Getting carbon dioxide detected state for '%s'...", this.id);
+    this.log.debug(this.name + ": Getting carbon dioxide detected state for '%s'...", this.id);
     var state = this.storage.getItemSync("http-webhook-carbon-dioxide-detected-" + this.id);
     if (state === undefined) {
         state = false;

--- a/src/homekit/accessories/HttpWebHookFanv2Accessory.js
+++ b/src/homekit/accessories/HttpWebHookFanv2Accessory.js
@@ -96,14 +96,14 @@ HttpWebHookFanv2Accessory.prototype.changeFromServer = function (urlParams) {
     var state = urlParams.state || cachedState;
     var stateBool = state === "true" || state === true;
     if (urlParams.state != cachedState) {
-        this.log("Change state for fanv2 to '%s'.", stateBool);
+        this.log(this.name + ": Change state for fanv2 to '%s'.", stateBool);
         this.service.getCharacteristic(Characteristic.Active).updateValue((urlParams.state == "true"), undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
     if (urlParams.speed != null) {
         var cachedSpeed = this.storage.getItemSync("http-webhook-speed-" + this.id);
         var speed = parseInt(urlParams.speed);
         if (cachedSpeed != speed) {
-            this.log("Change speed for fanv2 to '%d'.", speed);
+            this.log(this.name + ": Change speed for fanv2 to '%d'.", speed);
             this.service.getCharacteristic(Characteristic.RotationSpeed).updateValue(speed, undefined, Constants.CONTEXT_FROM_WEBHOOK);
         }
     }
@@ -111,7 +111,7 @@ HttpWebHookFanv2Accessory.prototype.changeFromServer = function (urlParams) {
         var cachedSwingMode = this.storage.getItemSync("http-webhook-swingmode-" + this.id);
         var swingMode = parseInt(urlParams.swingMode);
         if (cachedSwingMode != swingMode) {
-            this.log("Change swing mode for fanv2 to '%d'.", swingMode);
+            this.log(this.name + ": Change swing mode for fanv2 to '%d'.", swingMode);
             this.service.getCharacteristic(Characteristic.SwingMode).updateValue(swingMode, undefined, Constants.CONTEXT_FROM_WEBHOOK);
         }
     }
@@ -119,7 +119,7 @@ HttpWebHookFanv2Accessory.prototype.changeFromServer = function (urlParams) {
         var cachedRotationDirection = this.storage.getItemSync("http-webhook-rotationdirection-" + this.id);
         var rotationDirection = parseInt(urlParams.rotationDirection);
         if (cachedRotationDirection != rotationDirection) {
-            this.log("Change rotation direction for fanv2 to '%d'.", rotationDirection);
+            this.log(this.name + ": Change rotation direction for fanv2 to '%d'.", rotationDirection);
             this.service.getCharacteristic(Characteristic.RotationDirection).updateValue(rotationDirection, undefined, Constants.CONTEXT_FROM_WEBHOOK);
         }
     }
@@ -127,7 +127,7 @@ HttpWebHookFanv2Accessory.prototype.changeFromServer = function (urlParams) {
         var cachedLockstate = this.storage.getItemSync("http-webhook-lockstate-" + this.id);
         var lockstate = parseInt(urlParams.lockState);
         if (cachedLockstate != lockstate) {
-            this.log("Change lock state for fanv2 to '%d'.", lockstate);
+            this.log(this.name + ": Change lock state for fanv2 to '%d'.", lockstate);
             this.service.getCharacteristic(Characteristic.LockPhysicalControls).updateValue(lockstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
         }
     }
@@ -135,7 +135,7 @@ HttpWebHookFanv2Accessory.prototype.changeFromServer = function (urlParams) {
         var cachedTargetstate = this.storage.getItemSync("http-webhook-targetstate-" + this.id);
         var targetState = parseInt(urlParams.targetState);
         if (cachedTargetstate != targetState) {
-            this.log("Change target state for fanv2 to '%d'.", targetState);
+            this.log(this.name + ": Change target state for fanv2 to '%d'.", targetState);
             this.service.getCharacteristic(Characteristic.TargetFanState).updateValue(targetState, undefined, Constants.CONTEXT_FROM_WEBHOOK);
         }
     }
@@ -145,7 +145,7 @@ HttpWebHookFanv2Accessory.prototype.changeFromServer = function (urlParams) {
 }
 
 HttpWebHookFanv2Accessory.prototype.getState = function (callback) {
-    this.log.debug("Getting current state for '%s'...", this.id);
+    this.log.debug(this.name + ": Getting current state for '%s'...", this.id);
     var state = this.storage.getItemSync("http-webhook-" + this.id);
     if (state === undefined) {
         state = false;
@@ -154,7 +154,7 @@ HttpWebHookFanv2Accessory.prototype.getState = function (callback) {
 };
 
 HttpWebHookFanv2Accessory.prototype.setState = function (powerOn, callback, context) {
-    this.log("Fanv2 state for '%s'...", this.id);
+    this.log(this.name + ": Fanv2 state for '%s'...", this.id);
     this.storage.setItemSync("http-webhook-" + this.id, powerOn);
     var urlToCall = this.onURL;
     var urlMethod = this.onMethod;
@@ -172,7 +172,7 @@ HttpWebHookFanv2Accessory.prototype.setState = function (powerOn, callback, cont
 };
 
 HttpWebHookFanv2Accessory.prototype.getSpeed = function (callback) {
-    this.log.debug("Getting current speed for '%s'...", this.id);
+    this.log.debug(this.name + ": Getting current speed for '%s'...", this.id);
     var state = this.storage.getItemSync("http-webhook-" + this.id);
     if (state === undefined) {
         state = false;
@@ -188,7 +188,7 @@ HttpWebHookFanv2Accessory.prototype.getSpeed = function (callback) {
 };
 
 HttpWebHookFanv2Accessory.prototype.setSpeed = function (speed, callback, context) {
-    this.log("Fanv2 rotation speed for '%s'...", this.id);
+    this.log(this.name + ": Fanv2 rotation speed for '%s'...", this.id);
     var newState = speed > 0;
     this.storage.setItemSync("http-webhook-" + this.id, newState);
     this.storage.setItemSync("http-webhook-speed-" + this.id, speed);
@@ -211,7 +211,7 @@ HttpWebHookFanv2Accessory.prototype.setSpeed = function (speed, callback, contex
 };
 
 HttpWebHookFanv2Accessory.prototype.getLockState = function (callback) {
-    this.log.debug("Getting current lock state for '%s'...", this.id);
+    this.log.debug(this.name + ": Getting current lock state for '%s'...", this.id);
     var lockstate = this.storage.getItemSync("http-webhook-lockstate-" + this.id);
     if (lockstate === undefined) {
         lockstate = false;
@@ -220,7 +220,7 @@ HttpWebHookFanv2Accessory.prototype.getLockState = function (callback) {
 };
 
 HttpWebHookFanv2Accessory.prototype.setLockState = function (lockState, callback, context) {
-    this.log("Fanv2 lock state for '%s'...", this.id);
+    this.log(this.name + ": Fanv2 lock state for '%s'...", this.id);
     this.storage.setItemSync("http-webhook-lockstate-" + this.id, lockState);
     var urlToCall = this.lockURL;
     var urlMethod = this.lockMethod;
@@ -238,7 +238,7 @@ HttpWebHookFanv2Accessory.prototype.setLockState = function (lockState, callback
 };
 
 HttpWebHookFanv2Accessory.prototype.getTargetState = function (callback) {
-    this.log.debug("Getting current target state for '%s'...", this.id);
+    this.log.debug(this.name + ": Getting current target state for '%s'...", this.id);
     var targetState = this.storage.getItemSync("http-webhook-targetstate-" + this.id);
     if (targetState === undefined) {
         targetState = false;
@@ -247,7 +247,7 @@ HttpWebHookFanv2Accessory.prototype.getTargetState = function (callback) {
 };
 
 HttpWebHookFanv2Accessory.prototype.setTargetState = function (targetState, callback, context) {
-    this.log("Fanv2 target state for '%s'...", this.id);
+    this.log(this.name + ": Fanv2 target state for '%s'...", this.id);
     this.storage.setItemSync("http-webhook-targetstate-" + this.id, targetState);
     var state = this.storage.getItemSync("http-webhook-" + this.id);
     if (state === undefined) {
@@ -263,7 +263,7 @@ HttpWebHookFanv2Accessory.prototype.setTargetState = function (targetState, call
 };
 
 HttpWebHookFanv2Accessory.prototype.getSwingMode = function (callback) {
-    this.log.debug("Getting current swing mode for '%s'...", this.id);
+    this.log.debug(this.name + ": Getting current swing mode for '%s'...", this.id);
     var swingMode = this.storage.getItemSync("http-webhook-swingmode-" + this.id);
     if (swingMode === undefined) {
         swingMode = false;
@@ -272,7 +272,7 @@ HttpWebHookFanv2Accessory.prototype.getSwingMode = function (callback) {
 };
 
 HttpWebHookFanv2Accessory.prototype.setSwingMode = function (swingMode, callback, context) {
-    this.log("Fanv2 swing mode for '%s'...", this.id);
+    this.log(this.name + ": Fanv2 swing mode for '%s'...", this.id);
     this.storage.setItemSync("http-webhook-swingmode-" + this.id, swingMode);
     var state = this.storage.getItemSync("http-webhook-" + this.id);
     if (state === undefined) {
@@ -288,7 +288,7 @@ HttpWebHookFanv2Accessory.prototype.setSwingMode = function (swingMode, callback
 };
 
 HttpWebHookFanv2Accessory.prototype.getRotationDirection = function (callback) {
-    this.log.debug("Getting current rotation direction for '%s'...", this.id);
+    this.log.debug(this.name + ": Getting current rotation direction for '%s'...", this.id);
     var rotationDirection = this.storage.getItemSync("http-webhook-rotationdirection-" + this.id);
     if (rotationDirection === undefined) {
         rotationDirection = false;
@@ -297,7 +297,7 @@ HttpWebHookFanv2Accessory.prototype.getRotationDirection = function (callback) {
 };
 
 HttpWebHookFanv2Accessory.prototype.setRotationDirection = function (rotationDirection, callback, context) {
-    this.log("Fanv2 rotation direction for '%s'...", this.id);
+    this.log(this.name + ": Fanv2 rotation direction for '%s'...", this.id);
     this.storage.setItemSync("http-webhook-rotationdirection-" + this.id, rotationDirection);
     var urlToCall = this.rotationDirectionURL.replace("%rotationDirection", rotationDirection);
     var urlMethod = this.rotationDirectionMethod;

--- a/src/homekit/accessories/HttpWebHookGarageDoorOpenerAccessory.js
+++ b/src/homekit/accessories/HttpWebHookGarageDoorOpenerAccessory.js
@@ -44,7 +44,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.changeFromServer = function(urlPa
     this.storage.setItemSync("http-webhook-current-door-state-" + this.id, urlParams.currentdoorstate);
     if (cachedCurrentDoorState !== urlParams.currentdoorstate) {
       if (urlParams.currentdoorstate) {
-        this.log("Change Current Door State for garage door opener to '%s'.", urlParams.currentdoorstate);
+        this.log(this.name + ": Change Current Door State for garage door opener to '%s'.", urlParams.currentdoorstate);
         this.service.getCharacteristic(Characteristic.CurrentDoorState).updateValue(urlParams.currentdoorstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -57,7 +57,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.changeFromServer = function(urlPa
     this.storage.setItemSync("http-webhook-target-door-state-" + this.id, urlParams.targetdoorstate);
     if (cachedTargetDoorState !== urlParams.targetdoorstate) {
       if (urlParams.targetdoorstate) {
-        this.log("Change Target Door State for garage door opener to '%s'.", urlParams.targetdoorstate);
+        this.log(this.name + ": Change Target Door State for garage door opener to '%s'.", urlParams.targetdoorstate);
         this.service.getCharacteristic(Characteristic.TargetDoorState).updateValue(urlParams.targetdoorstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -70,7 +70,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.changeFromServer = function(urlPa
     this.storage.setItemSync("http-webhook-obstruction-detected-" + this.id, urlParams.obstructiondetected);
     if (cachedObstructionDetected !== urlParams.obstructiondetected) {
       if (urlParams.obstructiondetected) {
-        this.log("Change Obstruction Detected for garage door opener to '%s'.", urlParams.obstructiondetected);
+        this.log(this.name + ": Change Obstruction Detected for garage door opener to '%s'.", urlParams.obstructiondetected);
         this.service.getCharacteristic(Characteristic.ObstructionDetected).updateValue(urlParams.obstructiondetected, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -84,7 +84,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.changeFromServer = function(urlPa
 }
 
 HttpWebHookGarageDoorOpenerAccessory.prototype.getTargetDoorState = function(callback) {
-  this.log("Getting current Target Door State for '%s'...", this.id);
+  this.log(this.name + ": Getting current Target Door State for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-target-door-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.TargetDoorState.CLOSED;
@@ -93,7 +93,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.getTargetDoorState = function(cal
 };
 
 HttpWebHookGarageDoorOpenerAccessory.prototype.setTargetDoorState = function(newState, callback, context) {
-  this.log("Target Door State for '%s'...", this.id);
+  this.log(this.name + ": Target Door State for '%s'...", this.id);
   this.storage.setItemSync("http-webhook-target-door-state-" + this.id, newState);
 
   var doOpen = newState === Characteristic.TargetDoorState.OPEN;
@@ -118,7 +118,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.setTargetDoorState = function(new
 };
 
 HttpWebHookGarageDoorOpenerAccessory.prototype.getCurrentDoorState = function(callback) {
-  this.log("Getting Current Door State for '%s'...", this.id);
+  this.log(this.name + ": Getting Current Door State for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-current-door-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.CurrentDoorState.CLOSED;
@@ -127,7 +127,7 @@ HttpWebHookGarageDoorOpenerAccessory.prototype.getCurrentDoorState = function(ca
 };
 
 HttpWebHookGarageDoorOpenerAccessory.prototype.getObstructionDetected = function(callback) {
-  this.log("Getting Obstruction Detected for '%s'...", this.id);
+  this.log(this.name + ": Getting Obstruction Detected for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-obstruction-detected-" + this.id);
   if (state === undefined) {
     state = false;

--- a/src/homekit/accessories/HttpWebHookLightBulbAccessory.js
+++ b/src/homekit/accessories/HttpWebHookLightBulbAccessory.js
@@ -65,8 +65,8 @@ HttpWebHookLightBulbAccessory.prototype.changeFromServer = function(urlParams) {
     this.storage.setItemSync("http-webhook-brightness-" + this.id, brightnessInt);
     if (cachedState !== stateBool || cachedBrightness != brightnessInt) {
       var brightnessToSet = Math.ceil(brightnessInt / this.brightnessFactor);
-      this.log("Change HomeKit state for light to '%s'.", stateBool);
-      this.log("Change HomeKit brightness for light to '%s'.", brightnessToSet);
+      this.log(this.name + ": Change HomeKit state for light to '%s'.", stateBool);
+      this.log(this.name + ": Change HomeKit brightness for light to '%s'.", brightnessToSet);
       this.service.getCharacteristic(Characteristic.On).updateValue(stateBool, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       this.service.getCharacteristic(Characteristic.Brightness).updateValue(brightnessToSet, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
@@ -77,7 +77,7 @@ HttpWebHookLightBulbAccessory.prototype.changeFromServer = function(urlParams) {
 };
 
 HttpWebHookLightBulbAccessory.prototype.getState = function(callback) {
-  this.log.debug("Getting current state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-" + this.id);
   if (state === undefined) {
     state = false;
@@ -86,7 +86,7 @@ HttpWebHookLightBulbAccessory.prototype.getState = function(callback) {
 };
 
 HttpWebHookLightBulbAccessory.prototype.setState = function(powerOn, callback, context) {
-  this.log("Light state for '%s'...", this.id);
+  this.log(this.name + ": Light state for '%s'...", this.id);
   this.storage.setItemSync("http-webhook-" + this.id, powerOn);
   var urlToCall = this.onURL;
   var urlMethod = this.onMethod;
@@ -104,7 +104,7 @@ HttpWebHookLightBulbAccessory.prototype.setState = function(powerOn, callback, c
 };
 
 HttpWebHookLightBulbAccessory.prototype.getBrightness = function(callback) {
-  this.log.debug("Getting current brightness for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current brightness for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-" + this.id);
   if (state === undefined) {
     state = false;
@@ -120,7 +120,7 @@ HttpWebHookLightBulbAccessory.prototype.getBrightness = function(callback) {
 };
 
 HttpWebHookLightBulbAccessory.prototype.setBrightness = function(brightness, callback, context) {
-  this.log("Light brightness for '%s'...", this.id);
+  this.log(this.name + ": Light brightness for '%s'...", this.id);
   var newState = brightness > 0;
   this.storage.setItemSync("http-webhook-" + this.id, newState);
   this.storage.setItemSync("http-webhook-brightness-" + this.id, brightness);

--- a/src/homekit/accessories/HttpWebHookLockMechanismAccessory.js
+++ b/src/homekit/accessories/HttpWebHookLockMechanismAccessory.js
@@ -43,7 +43,7 @@ HttpWebHookLockMechanismAccessory.prototype.changeFromServer = function(urlParam
     this.storage.setItemSync("http-webhook-lock-current-state-" + this.id, urlParams.lockcurrentstate);
     if (cachedLockCurrentState !== urlParams.lockcurrentstate) {
       if (urlParams.lockcurrentstate) {
-        this.log("Change Current Lock State for locking to '%s'.", urlParams.lockcurrentstate);
+        this.log(this.name + ": Change Current Lock State for locking to '%s'.", urlParams.lockcurrentstate);
         this.service.getCharacteristic(Characteristic.LockCurrentState).updateValue(urlParams.lockcurrentstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -56,7 +56,7 @@ HttpWebHookLockMechanismAccessory.prototype.changeFromServer = function(urlParam
     this.storage.setItemSync("http-webhook-lock-target-state-" + this.id, urlParams.locktargetstate);
     if (cachedLockTargetState !== urlParams.locktargetstate) {
       if (urlParams.locktargetstate) {
-        this.log("Change Target Lock State for locking to '%s'.", urlParams.locktargetstate);
+        this.log(this.name + ": Change Target Lock State for locking to '%s'.", urlParams.locktargetstate);
         this.service.getCharacteristic(Characteristic.LockTargetState).updateValue(urlParams.locktargetstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -69,7 +69,7 @@ HttpWebHookLockMechanismAccessory.prototype.changeFromServer = function(urlParam
 }
 
 HttpWebHookLockMechanismAccessory.prototype.getLockTargetState = function(callback) {
-  this.log.debug("Getting current Target Lock State for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current Target Lock State for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-lock-target-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.LockTargetState.SECURED;
@@ -82,7 +82,7 @@ HttpWebHookLockMechanismAccessory.prototype.setLockTargetState = function(homeKi
   var newHomeKitState = doLock ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED;
   var newHomeKitStateTarget = doLock ? Characteristic.LockTargetState.SECURED : Characteristic.LockTargetState.UNSECURED;
 
-  this.log("Target Lock State for '%s' to '%s'...", this.id, doLock);
+  this.log(this.name + ": Target Lock State for '%s' to '%s'...", this.id, doLock);
   this.storage.setItemSync("http-webhook-lock-target-state-" + this.id, homeKitState);
   var urlToCall = this.setLockTargetStateCloseURL;
   var urlMethod = this.setLockTargetStateCloseMethod;
@@ -110,7 +110,7 @@ HttpWebHookLockMechanismAccessory.prototype.setLockTargetState = function(homeKi
 };
 
 HttpWebHookLockMechanismAccessory.prototype.getLockCurrentState = function(callback) {
-  this.log.debug("Getting Current Lock State for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting Current Lock State for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-lock-current-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.LockCurrentState.SECURED;

--- a/src/homekit/accessories/HttpWebHookOutletAccessory.js
+++ b/src/homekit/accessories/HttpWebHookOutletAccessory.js
@@ -59,7 +59,7 @@ HttpWebHookOutletAccessory.prototype.changeFromServer = function(urlParams) {
       // '%s'
       // to '%s'.",accessory.id,stateBool);
       if (cachedState !== stateBool) {
-        this.log("Change HomeKit state for outlet to '%s'.", stateBool);
+        this.log(this.name + ": Change HomeKit state for outlet to '%s'.", stateBool);
         this.service.getCharacteristic(Characteristic.On).updateValue(stateBool, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -71,7 +71,7 @@ HttpWebHookOutletAccessory.prototype.changeFromServer = function(urlParams) {
       // '%s'
       // to '%s'.",accessory.id,stateBool);
       if (cachedStateInUse !== stateOutletInUseBool) {
-        this.log("Change HomeKit stateInUse for outlet to '%s'.", stateOutletInUseBool);
+        this.log(this.name + ": Change HomeKit stateInUse for outlet to '%s'.", stateOutletInUseBool);
         this.service.getCharacteristic(Characteristic.OutletInUse).updateValue(stateOutletInUseBool, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -82,7 +82,7 @@ HttpWebHookOutletAccessory.prototype.changeFromServer = function(urlParams) {
 }
 
 HttpWebHookOutletAccessory.prototype.getState = function(callback) {
-  this.log.debug("Getting current state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-" + this.id);
   if (state === undefined) {
     state = false;
@@ -91,7 +91,7 @@ HttpWebHookOutletAccessory.prototype.getState = function(callback) {
 };
 
 HttpWebHookOutletAccessory.prototype.getStateInUse = function(callback) {
-  this.log.debug("Getting current state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current state for '%s'...", this.id);
   var stateInUse = this.storage.getItemSync("http-webhook-" + this.id + "-inUse");
   if (stateInUse === undefined) {
     stateInUse = false;
@@ -100,7 +100,7 @@ HttpWebHookOutletAccessory.prototype.getStateInUse = function(callback) {
 };
 
 HttpWebHookOutletAccessory.prototype.setState = function(powerOn, callback, context) {
-  this.log("Switch outlet state for '%s'...", this.id);
+  this.log(this.name + ": Switch outlet state for '%s'...", this.id);
   this.storage.setItemSync("http-webhook-" + this.id, powerOn);
   var urlToCall = this.onURL;
   var urlMethod = this.onMethod;

--- a/src/homekit/accessories/HttpWebHookPushButtonAccessory.js
+++ b/src/homekit/accessories/HttpWebHookPushButtonAccessory.js
@@ -40,7 +40,7 @@ HttpWebHookPushButtonAccessory.prototype.changeFromServer = function(urlParams) 
     // this.log("[INFO Http WebHook Server] State change of '%s'
     // to '%s'.",accessory.id,stateBool);
     if (stateBool) {
-      this.log("Change HomeKit state for push button to '%s'.", stateBool);
+      this.log(this.name + ": Change HomeKit state for push button to '%s'.", stateBool);
       this.service.getCharacteristic(Characteristic.On).updateValue(stateBool, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       setTimeout(function() {
         this.service.getCharacteristic(Characteristic.On).updateValue(false, undefined, Constants.CONTEXT_FROM_TIMEOUTCALL);
@@ -53,13 +53,13 @@ HttpWebHookPushButtonAccessory.prototype.changeFromServer = function(urlParams) 
 }
 
 HttpWebHookPushButtonAccessory.prototype.getState = function(callback) {
-  this.log.debug("Getting current state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current state for '%s'...", this.id);
   var state = false;
   callback(null, state);
 };
 
 HttpWebHookPushButtonAccessory.prototype.setState = function(powerOn, callback, context) {
-  this.log("Push buttons state change for '%s'...", this.id);
+  this.log(this.name + ": Push buttons state change for '%s'...", this.id);
   if (!powerOn) {
     callback(null);
   }

--- a/src/homekit/accessories/HttpWebHookSecurityAccessory.js
+++ b/src/homekit/accessories/HttpWebHookSecurityAccessory.js
@@ -44,7 +44,7 @@ HttpWebHookSecurityAccessory.prototype.changeFromServer = function(urlParams) {
   if (urlParams.currentstate != null) {
     this.storage.setItemSync("http-webhook-current-security-state-" + this.id, urlParams.currentstate);
     if (cachedCurrentState !== urlParams.currentstate) {
-      this.log("Change current state for security to '%d'.", urlParams.currentstate);
+      this.log(this.name + ": Change current state for security to '%d'.", urlParams.currentstate);
       this.service.getCharacteristic(Characteristic.SecuritySystemCurrentState).updateValue(urlParams.currentstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
   }
@@ -56,7 +56,7 @@ HttpWebHookSecurityAccessory.prototype.changeFromServer = function(urlParams) {
     }
     this.storage.setItemSync("http-webhook-target-security-state-" + this.id, urlParams.targetstate);
     if (cachedState !== urlParams.targetstate) {
-      this.log("Change target state for security to '%d'.", urlParams.targetstate);
+      this.log(this.name + ": Change target state for security to '%d'.", urlParams.targetstate);
       this.service.getCharacteristic(Characteristic.SecuritySystemTargetState).updateValue(urlParams.targetstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
   }
@@ -66,7 +66,7 @@ HttpWebHookSecurityAccessory.prototype.changeFromServer = function(urlParams) {
 }
 
 HttpWebHookSecurityAccessory.prototype.getTargetSecurityState = function(callback) {
-  this.log.debug("Getting Target Security state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting Target Security state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-target-security-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.SecuritySystemTargetState.DISARM;
@@ -75,7 +75,7 @@ HttpWebHookSecurityAccessory.prototype.getTargetSecurityState = function(callbac
 };
 
 HttpWebHookSecurityAccessory.prototype.setTargetSecurityState = function(newState, callback, context) {
-  this.log("Target Security state for '%s'...", this.id);
+  this.log(this.name + ": Target Security state for '%s'...", this.id);
   this.storage.setItemSync("http-webhook-target-security-state-" + this.id, newState);
   this.storage.setItemSync("http-webhook-current-security-state-" + this.id, newState);
   var urlToCall = this.setStateURL.replace("%d", newState);
@@ -89,7 +89,7 @@ HttpWebHookSecurityAccessory.prototype.setTargetSecurityState = function(newStat
 };
 
 HttpWebHookSecurityAccessory.prototype.getCurrentSecurityState = function(callback) {
-  this.log.debug("Getting Current Security state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting Current Security state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-current-security-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.SecuritySystemCurrentState.DISARMED;

--- a/src/homekit/accessories/HttpWebHookSensorAccessory.js
+++ b/src/homekit/accessories/HttpWebHookSensorAccessory.js
@@ -68,19 +68,19 @@ HttpWebHookSensorAccessory.prototype.changeFromServer = function(urlParams) {
   }
   var noUrlValue = isNumberBased ? urlParams.value === undefined : urlParams.state === undefined;
   if (noUrlValue) {
-    this.log.debug("No urlValue");
+    this.log.debug(this.name + ": No urlValue");
     return {
       "success" : true,
       "state" : cached
     };
   }
   var urlValue = isNumberBased ? urlParams.value : urlParams.state === "true";
-  this.log.debug("urlValue: "+ urlValue);
+  this.log.debug(this.name + ": urlValue: "+ urlValue);
   this.storage.setItemSync("http-webhook-" + this.id, urlValue);
-  this.log.debug("cached: "+ cached);
-  this.log.debug("cached !== urlValue: "+ (cached !== urlValue));
+  this.log.debug(this.name + ": cached: "+ cached);
+  this.log.debug(this.name + ": cached !== urlValue: "+ (cached !== urlValue));
   if (cached !== urlValue) {
-    this.log("Change HomeKit value for " + this.type + " sensor to '%s'.", urlValue);
+    this.log(this.name + ": Change HomeKit value for " + this.type + " sensor to '%s'.", urlValue);
 
     if (this.type === "contact") {
       this.service.getCharacteristic(Characteristic.ContactSensorState).updateValue(urlValue ? Characteristic.ContactSensorState.CONTACT_DETECTED : Characteristic.ContactSensorState.CONTACT_NOT_DETECTED, undefined, Constants.CONTEXT_FROM_WEBHOOK);
@@ -136,9 +136,9 @@ HttpWebHookSensorAccessory.prototype.changeFromServer = function(urlParams) {
 };
 
 HttpWebHookSensorAccessory.prototype.getState = function(callback) {
-  this.log.debug("Getting current state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-" + this.id);
-  this.log.debug("State for '%s' is '%s'", this.id, state);
+  this.log.debug(this.name + ": State for '%s' is '%s'", this.id, state);
   if (state === undefined) {
     state = false;
   }

--- a/src/homekit/accessories/HttpWebHookStatelessSwitchAccessory.js
+++ b/src/homekit/accessories/HttpWebHookStatelessSwitchAccessory.js
@@ -36,7 +36,7 @@ HttpWebHookStatelessSwitchAccessory.prototype.changeFromServer = function(urlPar
     for (var index = 0; index < this.service.length; index++) {
       var serviceName = this.service[index].getCharacteristic(Characteristic.Name).value;
       if (serviceName === urlParams.buttonName) {
-        this.log("Pressing '%s' with event '%i'", urlParams.buttonName, urlParams.event)
+        this.log(this.name + ": Pressing '%s' with event '%i'", urlParams.buttonName, urlParams.event)
         this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(urlParams.event, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }

--- a/src/homekit/accessories/HttpWebHookSwitchAccessory.js
+++ b/src/homekit/accessories/HttpWebHookSwitchAccessory.js
@@ -50,7 +50,7 @@ HttpWebHookSwitchAccessory.prototype.changeFromServer = function(urlParams) {
     // this.log("[INFO Http WebHook Server] State change of '%s'
     // to '%s'.",accessory.id,stateBool);
     if (cachedState !== stateBool) {
-      this.log("Change HomeKit state for switch to '%s'.", stateBool);
+      this.log(this.name + ": Change HomeKit state for switch to '%s'.", stateBool);
       this.service.getCharacteristic(Characteristic.On).updateValue(stateBool, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
     return {
@@ -60,7 +60,7 @@ HttpWebHookSwitchAccessory.prototype.changeFromServer = function(urlParams) {
 }
 
 HttpWebHookSwitchAccessory.prototype.getState = function(callback) {
-  this.log.debug("Getting current state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-" + this.id);
   if (state === undefined) {
     state = false;
@@ -69,7 +69,7 @@ HttpWebHookSwitchAccessory.prototype.getState = function(callback) {
 };
 
 HttpWebHookSwitchAccessory.prototype.setState = function(powerOn, callback, context) {
-  this.log("Switch state for '%s'...", this.id);
+  this.log(this.name + ": Switch state for '%s'...", this.id);
   this.storage.setItemSync("http-webhook-" + this.id, powerOn);
   var urlToCall = this.onURL;
   var urlMethod = this.onMethod;

--- a/src/homekit/accessories/HttpWebHookThermostatAccessory.js
+++ b/src/homekit/accessories/HttpWebHookThermostatAccessory.js
@@ -51,7 +51,7 @@ HttpWebHookThermostatAccessory.prototype.changeFromServer = function(urlParams) 
     }
     this.storage.setItemSync("http-webhook-current-temperature-" + this.id, urlParams.currenttemperature);
     if (cachedCurTemp !== urlParams.currenttemperature) {
-      this.log("Change current Temperature for thermostat to '%d'.", urlParams.currenttemperature);
+      this.log(this.name + ": Change current Temperature for thermostat to '%d'.", urlParams.currenttemperature);
       this.service.getCharacteristic(Characteristic.CurrentTemperature).updateValue(urlParams.currenttemperature, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
   }
@@ -62,7 +62,7 @@ HttpWebHookThermostatAccessory.prototype.changeFromServer = function(urlParams) 
     }
     this.storage.setItemSync("http-webhook-target-temperature-" + this.id, urlParams.targettemperature);
     if (cachedCurTemp !== urlParams.targettemperature) {
-      this.log("Change target Temperature for thermostat to '%d'.", urlParams.targettemperature);
+      this.log(this.name + ": Change target Temperature for thermostat to '%d'.", urlParams.targettemperature);
       this.service.getCharacteristic(Characteristic.TargetTemperature).updateValue(urlParams.targettemperature, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
   }
@@ -74,7 +74,7 @@ HttpWebHookThermostatAccessory.prototype.changeFromServer = function(urlParams) 
     this.storage.setItemSync("http-webhook-current-heating-cooling-state-" + this.id, urlParams.currentstate);
     if (cachedState !== urlParams.currentstate) {
       if (urlParams.currentstate) {
-        this.log("Change Current Heating Cooling State for thermostat to '%s'.", urlParams.currentstate);
+        this.log(this.name + ": Change Current Heating Cooling State for thermostat to '%s'.", urlParams.currentstate);
         this.service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(urlParams.currentstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -87,7 +87,7 @@ HttpWebHookThermostatAccessory.prototype.changeFromServer = function(urlParams) 
     this.storage.setItemSync("http-webhook-target-heating-cooling-state-" + this.id, urlParams.targetstate);
     if (cachedState !== urlParams.targetstate) {
       if (urlParams.targetstate) {
-        this.log("Change Target Heating Cooling State for thermostat to '%s'.", urlParams.targetstate);
+        this.log(this.name + ": Change Target Heating Cooling State for thermostat to '%s'.", urlParams.targetstate);
         this.service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(urlParams.targetstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -98,7 +98,7 @@ HttpWebHookThermostatAccessory.prototype.changeFromServer = function(urlParams) 
 }
 
 HttpWebHookThermostatAccessory.prototype.getTargetTemperature = function(callback) {
-  this.log.debug("Getting target temperature for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting target temperature for '%s'...", this.id);
   var temp = this.storage.getItemSync("http-webhook-target-temperature-" + this.id);
   if (temp === undefined) {
     temp = 20;
@@ -107,7 +107,7 @@ HttpWebHookThermostatAccessory.prototype.getTargetTemperature = function(callbac
 };
 
 HttpWebHookThermostatAccessory.prototype.setTargetTemperature = function(temp, callback, context) {
-  this.log("Target temperature for '%s'...", this.id);
+  this.log(this.name + ": Target temperature for '%s'...", this.id);
   this.storage.setItemSync("http-webhook-target-temperature-" + this.id, temp);
   var urlToCall = this.setTargetTemperatureURL.replace("%f", temp);
   var urlMethod = this.setTargetTemperatureMethod;
@@ -119,7 +119,7 @@ HttpWebHookThermostatAccessory.prototype.setTargetTemperature = function(temp, c
 };
 
 HttpWebHookThermostatAccessory.prototype.getCurrentTemperature = function(callback) {
-  this.log.debug("Getting current temperature for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current temperature for '%s'...", this.id);
   var temp = this.storage.getItemSync("http-webhook-current-temperature-" + this.id);
   if (temp === undefined) {
     temp = 20;
@@ -128,7 +128,7 @@ HttpWebHookThermostatAccessory.prototype.getCurrentTemperature = function(callba
 };
 
 HttpWebHookThermostatAccessory.prototype.getTargetHeatingCoolingState = function(callback) {
-  this.log.debug("Getting current Target Heating Cooling state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current Target Heating Cooling state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-target-heating-cooling-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.TargetHeatingCoolingState.OFF;
@@ -137,7 +137,7 @@ HttpWebHookThermostatAccessory.prototype.getTargetHeatingCoolingState = function
 };
 
 HttpWebHookThermostatAccessory.prototype.setTargetHeatingCoolingState = function(newState, callback, context) {
-  this.log("Target Heating Cooling state for '%s'...", this.id);
+  this.log(this.name + ": Target Heating Cooling state for '%s'...", this.id);
   this.storage.setItemSync("http-webhook-target-heating-cooling-state-" + this.id, newState);
   var urlToCall = this.setTargetHeatingCoolingStateURL.replace("%b", newState);
   var urlMethod = this.setTargetHeatingCoolingStateMethod;
@@ -149,7 +149,7 @@ HttpWebHookThermostatAccessory.prototype.setTargetHeatingCoolingState = function
 };
 
 HttpWebHookThermostatAccessory.prototype.getCurrentHeatingCoolingState = function(callback) {
-  this.log.debug("Getting current Target Heating Cooling state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current Target Heating Cooling state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-current-heating-cooling-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.CurrentHeatingCoolingState.OFF;

--- a/src/homekit/accessories/HttpWebHookValveAccessory.js
+++ b/src/homekit/accessories/HttpWebHookValveAccessory.js
@@ -79,7 +79,7 @@ HttpWebHookValveAccessory.prototype.changeFromServer = function(urlParams) {
             this.log.info("Change HomeKit value for " + this.type + " state to '%s'.", stateNumber);
 
             if (cachedState !== stateNumber) {
-                this.log("Change HomeKit state for valve to '%s'.", stateNumber);
+                this.log(this.name + ": Change HomeKit state for valve to '%s'.", stateNumber);
                 this.service.getCharacteristic(Characteristic.Active).updateValue(stateNumber, undefined, Constants.CONTEXT_FROM_WEBHOOK);
                 this.service.getCharacteristic(Characteristic.InUse).updateValue(stateNumber, undefined, Constants.CONTEXT_FROM_WEBHOOK);
             }
@@ -91,7 +91,7 @@ HttpWebHookValveAccessory.prototype.changeFromServer = function(urlParams) {
             this.log.info("Change HomeKit value for " + this.type + " statusFault to '%s'.", statusFaultNumber);
 
             if (cachedStatusFault !== statusFaultNumber) {
-                this.log("Change HomeKit statusFault for valve to '%s'.", statusFault);
+                this.log(this.name + ": Change HomeKit statusFault for valve to '%s'.", statusFault);
                 this.service.getCharacteristic(Characteristic.StatusFault).updateValue(statusFaultNumber, undefined, Constants.CONTEXT_FROM_WEBHOOK);
             }
         }
@@ -102,7 +102,7 @@ HttpWebHookValveAccessory.prototype.changeFromServer = function(urlParams) {
 };
 
 HttpWebHookValveAccessory.prototype.getState = function(callback) {
-    this.log.debug("Getting current state for", this.id);
+    this.log.debug(this.name + ": Getting current state for", this.id);
     var state = this.storage.getItemSync("http-webhook-" + this.id);
     if (state === undefined) {
         state = 0;
@@ -112,7 +112,7 @@ HttpWebHookValveAccessory.prototype.getState = function(callback) {
 };
 
 HttpWebHookValveAccessory.prototype.getStatusFault = function(callback) {
-    this.log.debug("Getting status fault for", this.id);
+    this.log.debug(this.name + ": Getting status fault for", this.id);
     var statusFault = this.storage.getItemSync("http-webhook-" + this.id + "-statusFault");
     if (statusFault === undefined) {
         statusFault = 0;

--- a/src/homekit/accessories/HttpWebHookWindowCoveringAccessory.js
+++ b/src/homekit/accessories/HttpWebHookWindowCoveringAccessory.js
@@ -64,7 +64,7 @@ HttpWebHookWindowCoveringAccessory.prototype.changeFromServer = function(urlPara
     }
     this.storage.setItemSync("http-webhook-current-position-" + this.id, urlParams.currentposition);
     if (cachedCurrentPosition !== urlParams.currentposition) {
-      this.log("Change Current Window Covering for covers to '%s'.", urlParams.currentposition);
+      this.log(this.name + ": Change Current Window Covering for covers to '%s'.", urlParams.currentposition);
       this.service.getCharacteristic(Characteristic.CurrentPosition).updateValue(urlParams.currentposition, undefined, Constants.CONTEXT_FROM_WEBHOOK);
     }
   }
@@ -77,7 +77,7 @@ HttpWebHookWindowCoveringAccessory.prototype.changeFromServer = function(urlPara
     this.storage.setItemSync("http-webhook-target-position-" + this.id, urlParams.targetposition);
     if (cachedTargetPosition !== urlParams.targetposition) {
       if (urlParams.targetposition) {
-        this.log("Change Target Position for covers to '%s'.", urlParams.targetposition);
+        this.log(this.name + ": Change Target Position for covers to '%s'.", urlParams.targetposition);
         this.service.getCharacteristic(Characteristic.TargetPosition).updateValue(urlParams.targetposition, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -90,7 +90,7 @@ HttpWebHookWindowCoveringAccessory.prototype.changeFromServer = function(urlPara
     this.storage.setItemSync("http-webhook-position-state-" + this.id, urlParams.positionstate);
     if (cachedPositionState !== urlParams.positionstate) {
       if (urlParams.positionstate) {
-        this.log("Change Position State for covers to '%s'.", urlParams.positionstate);
+        this.log(this.name + ": Change Position State for covers to '%s'.", urlParams.positionstate);
         this.service.getCharacteristic(Characteristic.PositionState).updateValue(urlParams.positionstate, undefined, Constants.CONTEXT_FROM_WEBHOOK);
       }
     }
@@ -104,7 +104,7 @@ HttpWebHookWindowCoveringAccessory.prototype.changeFromServer = function(urlPara
 }
 
 HttpWebHookWindowCoveringAccessory.prototype.getTargetPosition = function(callback) {
-  this.log.debug("Getting current Target Position for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting current Target Position for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-target-position-" + this.id);
   if (state === undefined) {
     state = 100;
@@ -113,8 +113,8 @@ HttpWebHookWindowCoveringAccessory.prototype.getTargetPosition = function(callba
 };
 
 HttpWebHookWindowCoveringAccessory.prototype.setTargetPosition = function(newState, callback, context) {
-  this.log("Target Position State for '%s'...", this.id);
-  this.log("New target state is: " + newState);
+  this.log(this.name + ": Target Position State for '%s'...", this.id);
+  this.log(this.name + ": New target state is: " + newState);
   this.storage.setItemSync("http-webhook-target-position-" + this.id, newState);
   if(this.autoSetCurrentPosition) {
     this.storage.setItemSync("http-webhook-current-position-" + this.id, newState);
@@ -170,7 +170,7 @@ HttpWebHookWindowCoveringAccessory.prototype.setTargetPosition = function(newSta
   Util.callHttpApi(this.log, urlToCall, urlMethod, urlBody, urlForm, urlHeaders, this.rejectUnauthorized, callback, context, (function() {
     this.service.getCharacteristic(Characteristic.TargetPosition).updateValue(newState, undefined, null);
     if(this.autoSetCurrentPosition) {
-      this.log("New current state is: " + newState);
+      this.log(this.name + ": New current state is: " + newState);
       setTimeout(function() {
         this.service.getCharacteristic(Characteristic.CurrentPosition).updateValue(newState, undefined, null);
       }.bind(this), 1000);
@@ -179,7 +179,7 @@ HttpWebHookWindowCoveringAccessory.prototype.setTargetPosition = function(newSta
 };
 
 HttpWebHookWindowCoveringAccessory.prototype.getCurrentPosition = function(callback) {
-  this.log.debug("Getting Current Position for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting Current Position for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-current-position-" + this.id);
   if (state === undefined) {
     state = 100;
@@ -188,7 +188,7 @@ HttpWebHookWindowCoveringAccessory.prototype.getCurrentPosition = function(callb
 };
 
 HttpWebHookWindowCoveringAccessory.prototype.getPositionState = function(callback) {
-  this.log.debug("Getting position state for '%s'...", this.id);
+  this.log.debug(this.name + ": Getting position state for '%s'...", this.id);
   var state = this.storage.getItemSync("http-webhook-position-state-" + this.id);
   if (state === undefined) {
     state = Characteristic.PositionState.STOPPED;


### PR DESCRIPTION
Adds Accessory Name (as configured in Homebridge) to every log entry to help determine which accessory generated the log entry. Useful when multiple accessories of the same type exist.

Resolves issue #173

This PR only changes the logging to add this.name, nothing else was changed.
I would like to harmonise and improve some of the logging text, but I'll do that in a future PR

I think this change alone would be enough to warrant publishing of a new version, but I'll leave it up to @benzman81 
