### PR TITLE
Add doorbell code

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ For switches you can call the url from any system to switch the switch on or off
 ## Push button
 For push buttons you can call the url from any system to push the button. The button will be released automatically.
 
+## Doorbell
+Doorbells require 2 parameters: accessoryId and the event to trigger:
+* Single press = 0
+* Double press = 1
+* Long press = 2
+`http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&event=EVENT`
+
+Examples:
+* Ring the doorbell with a single button press: `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&event=0`
+* Ring the doorbell with a long button press: `http://yourHomebridgeServerIp:webhook_port/?accessoryId=theAccessoryIdToUpdate&event=2`
+
+Doorbells are shown as a stateless programmable switch.
+When the doorbell is rung by calling the webhooks url, it generates the notification "Roomname doorbell rang." and executes any actions which have been added in the Home app to the stateless programmable switch.
+When adding the doorbell to the Home app, it will ask for somme options to recognise familiar faces. These can be ignored, as no camera is associated with the doorbell.
+
 ## Light
 For lights you can call the url from any system to switch the light on or off.
 
@@ -248,6 +263,14 @@ Example config.json:
                         "push_method": "GET", // (optional)
                         "push_body": "{ \"push\": true }", // (optional only for POST, PUT and PATCH; use "push_form" for x-www-form-urlencoded JSON)
                         "push_headers": "{\"Authorization\": \"Bearer ABCDEFGH\", \"Content-Type\": \"application/json\"}" // (optional)
+                    }
+                ],
+                "doorbells": [
+                    {
+                        "id": "doorbell1",
+                        "name": "Doorbell name 1",
+                        "double_press": false, // (optional, set to true to enable this action if desired)
+                        "long_press": false // (optional, set to true to enable this action if desired)
                     }
                 ],
                 "lights": [

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,7 +2,7 @@
   "pluginAlias": "HttpWebHooks",
   "pluginType": "platform",
   "singular": true,
-  "headerDisplay": "A `http` plugin with support of webhooks for homebridge.\n\nThe plugin gets its states from any system that is calling the url to trigger a state change.\n\nCurrently supports `contact`, `motion`, `occupancy`, `smoke`, `switches`, `push buttons`, `lights` (only on/off and brightness), `temperature`, `humidity`, `thermostats`, `co2sensors`, and `leak` sensors.",
+  "headerDisplay": "A `http` plugin with support of webhooks for homebridge.\n\nThe plugin gets its states from any system that is calling the url to trigger a state change.\n\nCurrently supports `contact`, `motion`, `occupancy`, `smoke`, `switches`, `push buttons`, `doorbells`, `lights` (only on/off and brightness), `temperature`, `humidity`, `thermostats`, `co2sensors`, and `leak` sensors.",
   "footerDisplay": "Visit the Project [Readme](https://github.com/benzman81/homebridge-http-webhooks#readme) for more details.",
   "schema": {
     "type": "object",
@@ -241,6 +241,39 @@
               "title": "Push Headers",
               "type": "string",
               "placeholder": "{\"Authorization\": \"Bearer ABCDEFGH\", \"Content-Type\": \"application/json\"}",
+              "required": false
+            }
+          }
+        }
+      },
+      "doorbells": {
+        "type": "array",
+        "title": "Doorbells",
+        "description": "Ring doorbells via a URL from any system.",
+        "items": {
+          "title": "Doorbells",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "string",
+              "placeholder": "doorbell1",
+              "required": false
+            },
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "placeholder": "Doorbell 1",
+              "required": false
+            },
+            "double_press": {
+              "title": "Enable Double Press",
+              "type": "boolean",
+              "required": false
+            },
+            "long_press": {
+              "title": "Enable Long Press",
+              "type": "boolean",
               "required": false
             }
           }
@@ -1402,7 +1435,7 @@
         },
         {
           "type": "section",
-          "title": "Push Button",
+          "title": "Push Buttons",
           "expandable": true,
           "expanded": false,
           "items": [
@@ -1418,6 +1451,25 @@
                 "pushbuttons[].push_method",
                 "pushbuttons[].push_body",
                 "pushbuttons[].push_headers"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "section",
+          "title": "Doorbells",
+          "expandable": true,
+          "expanded": false,
+          "items": [
+            {
+              "title": "Doorbell",
+              "type": "array",
+              "orderable": false,
+              "items": [
+                "doorbells[].id",
+                "doorbells[].name",
+                "doorbells[].double_press",
+                "doorbells[].long_press"
               ]
             }
           ]
@@ -1525,7 +1577,7 @@
         },
         {
           "type": "section",
-          "title": "Security",
+          "title": "Security Systems",
           "expandable": true,
           "expanded": false,
           "items": [

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var HttpWebHooksPlatform = require('./src/homekit/HttpWebHooksPlatform');
 var HttpWebHookSensorAccessory = require('./src/homekit/accessories/HttpWebHookSensorAccessory');
 var HttpWebHookSwitchAccessory = require('./src/homekit/accessories/HttpWebHookSwitchAccessory');
 var HttpWebHookPushButtonAccessory = require('./src/homekit/accessories/HttpWebHookPushButtonAccessory');
+var HttpWebHookDoorbellAccessory = require('./src/homekit/accessories/HttpWebHookDoorbellAccessory');
 var HttpWebHookLightBulbAccessory = require('./src/homekit/accessories/HttpWebHookLightBulbAccessory');
 var HttpWebHookThermostatAccessory = require('./src/homekit/accessories/HttpWebHookThermostatAccessory');
 var HttpWebHookOutletAccessory = require('./src/homekit/accessories/HttpWebHookOutletAccessory');
@@ -19,6 +20,7 @@ module.exports = function(homebridge) {
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookSensor", HttpWebHookSensorAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookSwitch", HttpWebHookSwitchAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookPushButton", HttpWebHookPushButtonAccessory);
+  homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookDoorbell", HttpWebHookDoorbellAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookLight", HttpWebHookLightBulbAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookThermostat", HttpWebHookThermostatAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookOutlet", HttpWebHookOutletAccessory);

--- a/src/homekit/HttpWebHooksPlatform.js
+++ b/src/homekit/HttpWebHooksPlatform.js
@@ -4,6 +4,7 @@ const Server = require('../Server');
 var HttpWebHookSensorAccessory = require('./accessories/HttpWebHookSensorAccessory');
 var HttpWebHookSwitchAccessory = require('./accessories/HttpWebHookSwitchAccessory');
 var HttpWebHookPushButtonAccessory = require('./accessories/HttpWebHookPushButtonAccessory');
+var HttpWebHookDoorbellAccessory = require('./accessories/HttpWebHookDoorbellAccessory');
 var HttpWebHookLightBulbAccessory = require('./accessories/HttpWebHookLightBulbAccessory');
 var HttpWebHookThermostatAccessory = require('./accessories/HttpWebHookThermostatAccessory');
 var HttpWebHookOutletAccessory = require('./accessories/HttpWebHookOutletAccessory');
@@ -32,6 +33,7 @@ function HttpWebHooksPlatform(log, config, homebridge) {
   this.sensors = config["sensors"] || [];
   this.switches = config["switches"] || [];
   this.pushButtons = config["pushbuttons"] || [];
+  this.doorbells = config["doorbells"] || [];
   this.lights = config["lights"] || [];
   this.thermostats = config["thermostats"] || [];
   this.outlets = config["outlets"] || [];
@@ -63,6 +65,11 @@ HttpWebHooksPlatform.prototype.accessories = function(callback) {
   for (var i = 0; i < this.pushButtons.length; i++) {
     var pushButtonsAccessory = new HttpWebHookPushButtonAccessory(Service, Characteristic, this, this.pushButtons[i]);
     accessories.push(pushButtonsAccessory);
+  }
+
+  for (var i = 0; i < this.doorbells.length; i++) {
+    var doorbellAccessory = new HttpWebHookDoorbellAccessory(Service, Characteristic, this, this.doorbells[i]);
+    accessories.push(doorbellAccessory);
   }
 
   for (var i = 0; i < this.lights.length; i++) {

--- a/src/homekit/accessories/HttpWebHookDoorbellAccessory.js
+++ b/src/homekit/accessories/HttpWebHookDoorbellAccessory.js
@@ -12,12 +12,12 @@ function HttpWebHookDoorbellAccessory(ServiceParam, CharacteristicParam, platfor
   this.type = "doorbell";
   this.name = doorbellConfig["name"];
 
-
-  // first service must be a StatelessProgrammableSwitch to be supported in the Home app. Only need one button for the doorbell
-  this.service = [];
   var single_press = doorbellConfig["single_press"] === undefined ? true : doorbellConfig["single_press"];
   var double_press = doorbellConfig["double_press"] === undefined ? true : doorbellConfig["double_press"];
   var long_press = doorbellConfig["long_press"] === undefined ? true : doorbellConfig["long_press"];
+
+  // first service must be a StatelessProgrammableSwitch to be supported in the Home app. Only need one button for the doorbell
+  this.service = [];
   var button = new Service.StatelessProgrammableSwitch(this.name,'sps');
   button.getCharacteristic(Characteristic.ProgrammableSwitchEvent).setProps(GetDoorbellStatelessSwitchProps(single_press, double_press, long_press));
   this.service.push(button);
@@ -25,6 +25,7 @@ function HttpWebHookDoorbellAccessory(ServiceParam, CharacteristicParam, platfor
 
   // add the Doorbell as a service
   var doorbell = new Service.Doorbell(this.name,'db');
+  doorbell.getCharacteristic(Characteristic.ProgrammableSwitchEvent).setProps(GetDoorbellStatelessSwitchProps(single_press, double_press, long_press));
   this.service.push(doorbell);
   
 
@@ -43,19 +44,32 @@ HttpWebHookDoorbellAccessory.prototype.changeFromServer = function(urlParams) {
     for (var index = 0; index < this.service.length; index++) {
       var serviceName = this.service[index].getCharacteristic(Characteristic.Name).value;
       var serviceSubtype = this.service[index].subtype;
+      var validValues = this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).props.validValues;
+
       // for service subtypes sps and db, update the value
       // db is the Doorbell, updateValue causes the HomeKit notification to be sent
       // sps is the StatelessProgrammableSwitch, updateValue causes any programmed switch actions to occur
-      if (['db','sps'].includes(serviceSubtype)) {
-        // we need updates for 2 x services, but we only want to do 1 x logging and so log only for the doorbell update
-        if (serviceSubtype === 'db') {
-          this.log(this.name + ": Pressing '%s' with event '%i'", serviceName, urlParams.event);
-          this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(urlParams.event, undefined, Constants.CONTEXT_FROM_WEBHOOK);
+      if ((['db','sps'].includes(serviceSubtype)) ) {
+        if (validValues.includes(Number(urlParams.event))) {
+          // event value is valid
+          // we need updates for 2 x services, but we only want to do 1 x logging and so log only for the doorbell update
+          if (serviceSubtype === 'db') {
+            this.log(this.name + ": Pressing '%s' with event '%i'", serviceName, urlParams.event);
+            this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(urlParams.event, undefined, Constants.CONTEXT_FROM_WEBHOOK);
+          }
+          // for the sps just do the update, no logging
+          if (serviceSubtype === 'sps') {
+            this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(urlParams.event, undefined, Constants.CONTEXT_FROM_WEBHOOK);
+          }
+        } else {
+          // event value is invalid
+          var errorText  = "event value " + urlParams.event + " is outside of valid values: " + validValues;
+          this.log.warn(this.name + ": WARNING: " + errorText);
+          return {
+            "error" : errorText
+          };
         }
-        // for the sps just do the update, no logging
-        if (serviceSubtype === 'sps') {
-          this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(urlParams.event, undefined, Constants.CONTEXT_FROM_WEBHOOK);
-        }
+
       }
      }
   }
@@ -69,13 +83,15 @@ function GetDoorbellStatelessSwitchProps(single_press, double_press, long_press)
   if (single_press && !double_press && !long_press) {
     props = {
       minValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
-      maxValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS
+      maxValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
+      validValues : [ Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS ]
     };
   }
   if (single_press && double_press && !long_press) {
     props = {
       minValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
-      maxValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS
+      maxValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS,
+      validValues : [ Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS, Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS ]
     };
   }
   if (single_press && !double_press && long_press) {
@@ -88,25 +104,29 @@ function GetDoorbellStatelessSwitchProps(single_press, double_press, long_press)
   if (!single_press && double_press && !long_press) {
     props = {
       minValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS,
-      maxValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS
+      maxValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS,
+      validValues : [ Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS ]
     };
   }
   if (!single_press && double_press && long_press) {
     props = {
       minValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS,
-      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS
+      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS,
+      validValues : [ Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS, Characteristic.ProgrammableSwitchEvent.LONG_PRESS ]
     };
   }
   if (!single_press && !double_press && long_press) {
     props = {
       minValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS,
-      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS
+      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS,
+      validValues : [ Characteristic.ProgrammableSwitchEvent.LONG_PRESS ]
     };
   }
   if (single_press && double_press && long_press) {
     props = {
       minValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
-      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS
+      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS,
+      validValues : [ Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS, Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS, Characteristic.ProgrammableSwitchEvent.LONG_PRESS ]
     };
   }
   return props;

--- a/src/homekit/accessories/HttpWebHookDoorbellAccessory.js
+++ b/src/homekit/accessories/HttpWebHookDoorbellAccessory.js
@@ -1,0 +1,119 @@
+const Constants = require('../../Constants');
+
+function HttpWebHookDoorbellAccessory(ServiceParam, CharacteristicParam, platform, doorbellConfig) {
+  Service = ServiceParam;
+  Characteristic = CharacteristicParam;
+
+  this.platform = platform;
+  this.log = platform.log;
+  this.storage = platform.storage;
+
+  this.id = doorbellConfig["id"];
+  this.type = "doorbell";
+  this.name = doorbellConfig["name"];
+
+
+  // first service must be a StatelessProgrammableSwitch to be supported in the Home app. Only need one button for the doorbell
+  this.service = [];
+  var single_press = doorbellConfig["single_press"] === undefined ? true : doorbellConfig["single_press"];
+  var double_press = doorbellConfig["double_press"] === undefined ? true : doorbellConfig["double_press"];
+  var long_press = doorbellConfig["long_press"] === undefined ? true : doorbellConfig["long_press"];
+  var button = new Service.StatelessProgrammableSwitch(this.name,'sps');
+  button.getCharacteristic(Characteristic.ProgrammableSwitchEvent).setProps(GetDoorbellStatelessSwitchProps(single_press, double_press, long_press));
+  this.service.push(button);
+
+
+  // add the Doorbell as a service
+  var doorbell = new Service.Doorbell(this.name,'db');
+  this.service.push(doorbell);
+  
+
+  // add the AccessoryInformation as a service
+  var informationService = new Service.AccessoryInformation();
+  informationService.setCharacteristic(Characteristic.Manufacturer, "HttpWebHooksPlatform");
+  informationService.setCharacteristic(Characteristic.Model, "HttpWebHookDoorbellAccessory-" + this.name);
+  informationService.setCharacteristic(Characteristic.SerialNumber, this.id);
+  this.service.push(informationService);
+
+};
+
+HttpWebHookDoorbellAccessory.prototype.changeFromServer = function(urlParams) {
+  if (urlParams.event && urlParams.event) {
+    // loop each service to find the Doorbell and StatelessProgrammableSwitch services
+    for (var index = 0; index < this.service.length; index++) {
+      var serviceName = this.service[index].getCharacteristic(Characteristic.Name).value;
+      var serviceSubtype = this.service[index].subtype;
+      // for service subtypes sps and db, update the value
+      // db is the Doorbell, updateValue causes the HomeKit notification to be sent
+      // sps is the StatelessProgrammableSwitch, updateValue causes any programmed switch actions to occur
+      if (['db','sps'].includes(serviceSubtype)) {
+        // we need updates for 2 x services, but we only want to do 1 x logging and so log only for the doorbell update
+        if (serviceSubtype === 'db') {
+          this.log(this.name + ": Pressing '%s' with event '%i'", serviceName, urlParams.event);
+          this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(urlParams.event, undefined, Constants.CONTEXT_FROM_WEBHOOK);
+        }
+        // for the sps just do the update, no logging
+        if (serviceSubtype === 'sps') {
+          this.service[index].getCharacteristic(Characteristic.ProgrammableSwitchEvent).updateValue(urlParams.event, undefined, Constants.CONTEXT_FROM_WEBHOOK);
+        }
+      }
+     }
+  }
+  return {
+    "success" : true
+  };
+}
+
+function GetDoorbellStatelessSwitchProps(single_press, double_press, long_press) {
+  var props;
+  if (single_press && !double_press && !long_press) {
+    props = {
+      minValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
+      maxValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS
+    };
+  }
+  if (single_press && double_press && !long_press) {
+    props = {
+      minValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
+      maxValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS
+    };
+  }
+  if (single_press && !double_press && long_press) {
+    props = {
+      minValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
+      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS,
+      validValues : [ Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS, Characteristic.ProgrammableSwitchEvent.LONG_PRESS ]
+    };
+  }
+  if (!single_press && double_press && !long_press) {
+    props = {
+      minValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS,
+      maxValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS
+    };
+  }
+  if (!single_press && double_press && long_press) {
+    props = {
+      minValue : Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS,
+      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS
+    };
+  }
+  if (!single_press && !double_press && long_press) {
+    props = {
+      minValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS,
+      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS
+    };
+  }
+  if (single_press && double_press && long_press) {
+    props = {
+      minValue : Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS,
+      maxValue : Characteristic.ProgrammableSwitchEvent.LONG_PRESS
+    };
+  }
+  return props;
+}
+
+HttpWebHookDoorbellAccessory.prototype.getServices = function() {
+  return this.service;
+};
+
+module.exports = HttpWebHookDoorbellAccessory;


### PR DESCRIPTION
The doorbell was requested in issue #143 so i thought I would add it for you as a stateless programmable switch.
It could also be anything else, such as a pushbutton, but the stateless programmable switch made moste sense in the Home app.

You can trigger the doorbell using standard webhooks commands for the stateless programmable switch:
http://localhost:51828/?accessoryId=doorbell1&event=0 // ring the doorbell using single press
http://localhost:51828/?accessoryId=doorbell1&event=1 // ring the doorbell using double press
http://localhost:51828/?accessoryId=doorbell1&event=2 // ring the doorbell using long press

When the doorbell is rung, it will send the standard HomeKit notification "Roomname doorbell rang", and it will trigger any actions added in the Home app to the stateless programmable switch

The code is based on HttpWebHookStatelessSwitchAccessory, but limited to one button only (as multiple buttons make no sense for a doorbell).

The doorbell does not trigger any urls to be called (but neither does HttpWebHookStatelessSwitchAccessory)

This is worthy of a new release, but wait a day or so, as I will update the readme comments and config.json for the stateless programmable switch as a separate PR (to make the readme more understandable)

