### PR TITLE
Improved readme and config for stateless switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,14 +340,16 @@ Example config.json:
                     {
                     "id": "statelessswitch1",
                     "name": "Stateless Switch 1",
-                    "buttons": [//the buttons of the switch
+                    "buttons": [ //the buttons of the switch
                         {
                             "name": "Button1" // (The name does not appear in Home app but appear in Eve app)
+                            "double_press": false, // (optional, set to true to enable this action if desired)
+                            "long_press": false // (optional, set to true to enable this action if desired)
                         },
                         {
                             "name": "Button2", // (The name does not appear in Home app but appear in Eve app)
-                            "double_press": false, // (you can disable a type of action)
-                            "long_press": false
+                            "double_press": false, // (optional, set to true to enable this action if desired)
+                            "long_press": false // (optional, set to true to enable this action if desired)
                         }
                     ]
                     }

--- a/config.schema.json
+++ b/config.schema.json
@@ -722,12 +722,12 @@
                     "required": false
                   },
                   "double_press": {
-                    "title": "Double Press",
+                    "title": "Enable Double Press",
                     "type": "boolean",
                     "required": false
                   },
                   "long_press": {
-                    "title": "Long Press",
+                    "title": "Enable Long Press",
                     "type": "boolean",
                     "required": false
                   }


### PR DESCRIPTION
Improved readme and config for stateless switch

I had to work my way through the stateless switch code to understand what the boolean options for double_press and long_press in the config.json did, as I did not understand he readme. 

This PR improves the readability and understanding of the stateless switch boolean options for double_press and long_press.

