### PR TITLE
Fix CO2 sensor not appearing in HomeKit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ package-lock.json
 .cache
 .idea
 .DS_Store
+/tmp
+.cursor
+*.icloud

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var HttpWebHookStatelessSwitchAccessory = require('./src/homekit/accessories/Htt
 var HttpWebHookLockMechanismAccessory = require('./src/homekit/accessories/HttpWebHookLockMechanismAccessory');
 var HttpWebHookWindowCoveringAccessory = require('./src/homekit/accessories/HttpWebHookWindowCoveringAccessory');
 var HttpWebHookFanv2Accessory = require('./src/homekit/accessories/HttpWebHookFanv2Accessory');
-var HttpWebHookCarbonDioxideSensoryAccessory = require('./src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory');
+var HttpWebHookCarbonDioxideSensorAccessory = require('./src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory');
 var HttpWebHookValveAccessory = require('./src/homekit/accessories/HttpWebHookValveAccessory');
 
 module.exports = function(homebridge) {
@@ -30,6 +30,6 @@ module.exports = function(homebridge) {
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookLockMechanism", HttpWebHookLockMechanismAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookWindowCovering", HttpWebHookWindowCoveringAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookFanv2", HttpWebHookFanv2Accessory);
-  homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookCarbonDioxideSensor", HttpWebHookCarbonDioxideSensoryAccessory);
+  homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookCarbonDioxideSensor", HttpWebHookCarbonDioxideSensorAccessory);
   homebridge.registerAccessory("homebridge-http-webhooks", "HttpWebHookValve", HttpWebHookValveAccessory);
 };

--- a/src/homekit/HttpWebHooksPlatform.js
+++ b/src/homekit/HttpWebHooksPlatform.js
@@ -14,7 +14,7 @@ var HttpWebHookStatelessSwitchAccessory = require('./accessories/HttpWebHookStat
 var HttpWebHookLockMechanismAccessory = require('./accessories/HttpWebHookLockMechanismAccessory');
 var HttpWebHookWindowCoveringAccessory = require('./accessories/HttpWebHookWindowCoveringAccessory');
 var HttpWebHookFanv2Accessory = require('./accessories/HttpWebHookFanv2Accessory');
-var HttpWebHookCarbonDioxideSensoryAccessory = require('./accessories/HttpWebHookCarbonDioxideSensorAccessory');
+var HttpWebHookCarbonDioxideSensorAccessory = require('./accessories/HttpWebHookCarbonDioxideSensorAccessory');
 var HttpWebHookValveAccessory = require('./accessories/HttpWebHookValveAccessory');
 
 var Service, Characteristic;
@@ -118,7 +118,7 @@ HttpWebHooksPlatform.prototype.accessories = function(callback) {
   }
 
   for (var i = 0; i < this.co2sensors.length; i++) {
-    var co2sensorAccessory = new HttpWebHookCarbonDioxideSensoryAccessory(Service, Characteristic, this, this.co2sensors[i]);
+    var co2sensorAccessory = new HttpWebHookCarbonDioxideSensorAccessory(Service, Characteristic, this, this.co2sensors[i]);
     accessories.push(co2sensorAccessory);
   }
 

--- a/src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory.js
+++ b/src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory.js
@@ -1,8 +1,8 @@
 const Constants = require('../../Constants');
 
 function HttpWebHookCarbonDioxideSensorAccessory(ServiceParam, CharacteristicParam, platform, sensorConfig) {
-  var Service = ServiceParam;
-  var Characteristic = CharacteristicParam;
+  Service = ServiceParam;
+  Characteristic = CharacteristicParam;
 
   this.platform = platform;
   this.log = platform.log;

--- a/src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory.js
+++ b/src/homekit/accessories/HttpWebHookCarbonDioxideSensorAccessory.js
@@ -1,8 +1,8 @@
 const Constants = require('../../Constants');
 
 function HttpWebHookCarbonDioxideSensorAccessory(ServiceParam, CharacteristicParam, platform, sensorConfig) {
-  Service = ServiceParam;
-  Characteristic = CharacteristicParam;
+  var Service = ServiceParam;
+  var Characteristic = CharacteristicParam;
 
   this.platform = platform;
   this.log = platform.log;
@@ -24,7 +24,10 @@ function HttpWebHookCarbonDioxideSensorAccessory(ServiceParam, CharacteristicPar
 }
 
 HttpWebHookCarbonDioxideSensorAccessory.prototype.changeFromServer = function(urlParams) {
-  var cached = this.storage.getItemSync("http-webhook-" + this.id) || 0;
+  var cached = this.storage.getItemSync("http-webhook-carbon-dioxide-level-" + this.id);
+  if (cached === undefined) {
+    cached = 0;
+  }
   if (urlParams.value === undefined) {
     this.log.debug(this.name + ": No urlValue");
     return {
@@ -32,7 +35,7 @@ HttpWebHookCarbonDioxideSensorAccessory.prototype.changeFromServer = function(ur
       "state" : cached
     };
   }
-  var urlValue = urlParams.value;
+  var urlValue = parseFloat(urlParams.value);
   var co2Detected = urlValue > this.co2PeakLevel;
   this.log.debug(this.name + ": urlValue: "+ urlValue);
   this.log.debug(this.name + ": co2Detected: "+ co2Detected);


### PR DESCRIPTION
Fixes typo in CO2 sensor accessory class name that prevented devices from being registered in HomeKit platform.